### PR TITLE
Goes to User Details View when clicked on user info of a post, closes #13

### DIFF
--- a/app/src/main/java/com/example/dogbook/main/adapters/PostDetailsAdapter.java
+++ b/app/src/main/java/com/example/dogbook/main/adapters/PostDetailsAdapter.java
@@ -7,6 +7,7 @@ import android.view.ViewGroup;
 import android.widget.Adapter;
 
 import androidx.annotation.NonNull;
+import androidx.fragment.app.FragmentManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.dogbook.R;
@@ -24,11 +25,13 @@ public class PostDetailsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHo
     private static final int TYPE_COMMENT = 2;
 
     private Context context;
+    private FragmentManager fragmentManager;
     public Post post;
     private List<Comment> comments;
 
-    public PostDetailsAdapter(Context context, Post post, List<Comment> comments) {
+    public PostDetailsAdapter(Context context, FragmentManager fragmentManager, Post post, List<Comment> comments) {
         this.context = context;
+        this.fragmentManager = fragmentManager;
         this.post = post;
         this.comments = comments;
     }
@@ -38,7 +41,7 @@ public class PostDetailsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHo
     public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
         if (viewType == TYPE_POST) {
             View view = LayoutInflater.from(context).inflate(R.layout.item_post, parent, false);
-            return new PostViewHolder(view, context, this);
+            return new PostViewHolder(view, context, this, fragmentManager);
         }
         View view = LayoutInflater.from(context).inflate(R.layout.item_comment, parent, false);
         return new CommentViewHolder(view, context);

--- a/app/src/main/java/com/example/dogbook/main/adapters/PostsAdapter.java
+++ b/app/src/main/java/com/example/dogbook/main/adapters/PostsAdapter.java
@@ -22,18 +22,19 @@ public class PostsAdapter extends RecyclerView.Adapter<PostViewHolder> {
 
     public List<Post> posts;
     private Context context;
-    public OnItemClickListener clickListener;
+    private FragmentManager fragmentManager;
 
-    public PostsAdapter(Context context, List<Post> posts) {
+    public PostsAdapter(Context context, FragmentManager fragmentManager, List<Post> posts) {
         this.posts = posts;
         this.context = context;
+        this.fragmentManager = fragmentManager;
     }
 
     @NonNull
     @Override
     public PostViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
         View view = LayoutInflater.from(context).inflate(R.layout.item_post, parent, false);
-        return new PostViewHolder(view, context, this);
+        return new PostViewHolder(view, context, this, fragmentManager);
     }
 
     @Override
@@ -50,13 +51,5 @@ public class PostsAdapter extends RecyclerView.Adapter<PostViewHolder> {
     public void onViewRecycled(@NonNull PostViewHolder holder) {
         super.onViewRecycled(holder);
         holder.recycle();
-    }
-
-    public void setOnItemClickListener(OnItemClickListener clickListener) {
-        this.clickListener = clickListener;
-    }
-
-    public interface OnItemClickListener {
-        void onItemClick(int position, View v);
     }
 }

--- a/app/src/main/java/com/example/dogbook/main/fragments/PostDetailsFragment.java
+++ b/app/src/main/java/com/example/dogbook/main/fragments/PostDetailsFragment.java
@@ -72,7 +72,7 @@ public class PostDetailsFragment extends Fragment {
     private void initView(View view) {
         rvPostDetails = view.findViewById(R.id.rvPostDetails);
         comments = new ArrayList<>();
-        adapter = new PostDetailsAdapter(getContext(), post, comments);
+        adapter = new PostDetailsAdapter(getContext(), getParentFragmentManager(), post, comments);
         LinearLayoutManager layoutManager = new LinearLayoutManager(getContext());
         rvPostDetails.setAdapter(adapter);
         rvPostDetails.setLayoutManager(layoutManager);

--- a/app/src/main/java/com/example/dogbook/main/fragments/TimelineFragment.java
+++ b/app/src/main/java/com/example/dogbook/main/fragments/TimelineFragment.java
@@ -77,17 +77,7 @@ public class TimelineFragment extends Fragment {
     }
 
     private void setUpRecyclerView() {
-        postsAdapter = new PostsAdapter(getContext(), posts);
-        postsAdapter.setOnItemClickListener(new PostsAdapter.OnItemClickListener() {
-            @Override
-            public void onItemClick(int position, View v) {
-                PostDetailsFragment fragment = new PostDetailsFragment();
-                fragmentManager.beginTransaction()
-                        .replace(R.id.timelineFragmentContainer, PostDetailsFragment.newInstance(posts.get(position)))
-                        .addToBackStack(null)
-                        .commit();
-            }
-        });
+        postsAdapter = new PostsAdapter(getContext(), fragmentManager, posts);
         rvPosts.setAdapter(postsAdapter);
         LinearLayoutManager layoutManager = new LinearLayoutManager(getContext());
         rvPosts.setLayoutManager(layoutManager);

--- a/app/src/main/java/com/example/dogbook/main/viewholders/PostViewHolder.java
+++ b/app/src/main/java/com/example/dogbook/main/viewholders/PostViewHolder.java
@@ -7,12 +7,15 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.fragment.app.FragmentManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.bumptech.glide.Glide;
 import com.example.dogbook.main.data.PostReactions;
 import com.example.dogbook.main.adapters.PostDetailsAdapter;
 import com.example.dogbook.main.adapters.PostsAdapter;
+import com.example.dogbook.main.fragments.PostDetailsFragment;
+import com.example.dogbook.main.fragments.ProfileDetailsFragment;
 import com.example.dogbook.main.models.Post;
 import com.example.dogbook.R;
 import com.example.dogbook.main.models.User;
@@ -21,6 +24,7 @@ import com.parse.ParseFile;
 public class PostViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
 
     private Context context;
+    private FragmentManager fragmentManager;
     private RecyclerView.Adapter adapter;
 
     private ImageView ivProfilePicture;
@@ -33,7 +37,7 @@ public class PostViewHolder extends RecyclerView.ViewHolder implements View.OnCl
     private TextView tvLikeCount;
     private TextView tvCommentCount;
 
-    public PostViewHolder(@NonNull View itemView, Context context, RecyclerView.Adapter adapter) {
+    public PostViewHolder(@NonNull View itemView, Context context, RecyclerView.Adapter adapter, FragmentManager fragmentManager) {
         super(itemView);
         ivProfilePicture = itemView.findViewById(R.id.ivProfilePicture);
         ivPostPicture = itemView.findViewById(R.id.ivPostPicture);
@@ -45,10 +49,15 @@ public class PostViewHolder extends RecyclerView.ViewHolder implements View.OnCl
         tvLikeCount = itemView.findViewById(R.id.tvLikeCount);
         tvCommentCount = itemView.findViewById(R.id.tvCommentCount);
         this.context = context;
+        this.fragmentManager = fragmentManager;
         this.adapter = adapter;
 
         itemView.setOnClickListener(this);
         cbLike.setOnClickListener(this);
+        tvUsername.setOnClickListener(this);
+        tvOwner.setOnClickListener(this);
+        ivProfilePicture.setOnClickListener(this);
+
     }
 
     public void bind(Post post) {
@@ -138,10 +147,21 @@ public class PostViewHolder extends RecyclerView.ViewHolder implements View.OnCl
             return;
         }
 
+        //Go to User Details Fragment
+        if (v == tvUsername || v == tvOwner || v == ivProfilePicture) {
+            fragmentManager.beginTransaction()
+                    .replace(R.id.timelineFragmentContainer, ProfileDetailsFragment.newInstance((User) post.getAuthor()))
+                    .addToBackStack(null)
+                    .commit();
+            return;
+        }
 
         //Add click listener to the entire item only if it is in the Posts Adapter
-        if (adapter instanceof PostsAdapter && ((PostsAdapter) adapter).clickListener != null) {
-            ((PostsAdapter) adapter).clickListener.onItemClick(getAdapterPosition(),v);
+        if (adapter instanceof PostsAdapter) {
+            fragmentManager.beginTransaction()
+                    .replace(R.id.timelineFragmentContainer, PostDetailsFragment.newInstance(post))
+                    .addToBackStack(null)
+                    .commit();
         }
     }
 }


### PR DESCRIPTION
Also for the entire post item click listener, replaced the code from the timeline fragment to the PostViewHolder, in order to have all the onClick logic for the entire item in the same place.

Demo:
![Kapture 2021-08-04 at 17 00 35](https://user-images.githubusercontent.com/67114468/128260942-85d5d3c3-44bc-4df9-8cc7-4eb7ca9e1c03.gif)
