### PR TITLE
'Liked by' optimization, shows any users in case followed users haven't liked the post

### DIFF
--- a/backend code_cloud_functions/main.js
+++ b/backend code_cloud_functions/main.js
@@ -12,6 +12,8 @@ const KEY_FOLLOWED_USER = "followedUser";
 const KEY_FOLLOWING_USER = "followingUser";
 const KEY_USERNAME = "username";
 
+const LIKED_BY_USERS_LIMIT = 3;
+
 var followedUsers= []
 
 //Retrieve 20 posts with all the info needed to populate the timeline
@@ -36,7 +38,7 @@ Parse.Cloud.define("getTimeline", async(request) => {
         reactions["isLiked"] = await isPostLiked(posts[i], request.user);
         reactions["likesCount"] = await getLikesCount(posts[i]);
         reactions["commentsCount"] = await getCommentCount(posts[i]);
-        reactions["likedBy"] = await getLikedByFollowedUsers(posts[i], followedUsers);
+        reactions["likedBy"] = await getLikedByUsers(posts[i], followedUsers, reactions["likesCount"]);
 
         //Build item that will be in final list
         postWithInfo["post"] = posts[i];
@@ -82,12 +84,49 @@ async function getCommentCount(post) {
     return await query.count();
 }
 
-async function getLikedByFollowedUsers(post, followedUsers) {
+async function getLikedByUsers(post, followedUsers, postLikesCount) {
+
+    //Do not make any fetches if the post does not have any likes
+    if (postLikesCount == 0) {
+        return [];
+    }
+
+    let likedByLimit = postLikesCount > LIKED_BY_USERS_LIMIT ? LIKED_BY_USERS_LIMIT : postLikesCount; //Set the number of users that will be searched
+    //If the number of likes of the post is less than the limit, then just look for any likes to fill the array
+    if (postLikesCount <= likedByLimit) {
+        return getLikedByAnyUsers(post, likedByLimit);
+    }
+
+    //Look up for followed users first
+    let likedBy = await getLikedByFollowedUsers(post, followedUsers, likedByLimit);
+
+    //If the likes by follow users do not fill the limit, look up for any users to fill it
+    if (likedBy.length < likedByLimit) {
+        let anyUsers = await getLikedByAnyUsers(post, likedByLimit - likedBy.length);
+        likedBy = likedBy.concat(anyUsers);
+    }
+    return likedBy;
+}
+
+//Get any likes of a post
+async function getLikedByAnyUsers(post, limit) {
+    query = new Parse.Query(CLASS_LIKE);
+    query.equalTo(KEY_POST, post);
+    query.select(KEY_AUTHOR);
+    query.select(KEY_AUTHOR + "." + KEY_USERNAME);
+    query.limit(limit);
+
+    return await query.find();
+
+}
+
+//Get likes from post only from followed users
+async function getLikedByFollowedUsers(post, followedUsers, limit) {
     let query = new Parse.Query(CLASS_LIKE);
     query.equalTo(KEY_POST, post);
     query.containedIn(KEY_AUTHOR, followedUsers);
     query.select(KEY_AUTHOR);
     query.select(KEY_AUTHOR + "." + KEY_USERNAME);
-    query.limit(3);
+    query.limit(limit);
     return await query.find();
 }


### PR DESCRIPTION
Demo explanation:
Context: 
The 'liked by' legend has a limit for show a maximum of 3 users. It will give priority to the followed users and show them first.
For the demo, the current user follows bela, aina, and sally; and does not follow aina and akira.
Testcases:
For the first post in the timeline, there are 3 likes from followed users and a like from an unfollowed user (shows only the followed users).
For the second, there are 2 likes from followed and a like from an unfollowed. It show first the two followed users and then the unfollowed user.
The third one only has two likes from unfollowed users. It shows both.
The last one has no likes.

![Kapture 2021-08-06 at 12 17 48](https://user-images.githubusercontent.com/67114468/128548251-dd2c9fec-ee8b-475f-9476-dca143863d32.gif)
